### PR TITLE
El scraping de metadata se hace tambien con estenografia

### DIFF
--- a/dotesting.py
+++ b/dotesting.py
@@ -10,6 +10,7 @@ import contextlib
 import random
 from contextlib import *
 import datetime
+from stegano import lsb
 
 from main.webhook_message import WebhookMessage
 from main.embed.info import Info
@@ -167,6 +168,32 @@ async def eval(ctx, *, body: str):
         else:
             await ctx.send(f'```py\n{value}\n```')
 
+def get_metadata_from_xmp(d):
+    xmp_start = d.find(b'<x:xmpmeta')
+    xmp_end = d.find(b'</x:xmpmeta')
+    xmp_str = d[xmp_start:xmp_end+12]
+    if not xmp_str:
+        return None
+    o = xmltodict.parse(xmp_str)
+    meta_string = json.dumps(o)
+    meta = json.loads(meta_string)
+    meta = meta["x:xmpmeta"]["rdf:RDF"]["rdf:Description"]
+    notebook = meta["dc:creator"]["rdf:Seq"]["rdf:li"]
+    title = meta["dc:title"]["rdf:Seq"]["rdf:li"]
+    model = meta["dc:model"]["rdf:Seq"]["rdf:li"]
+    i = meta["dc:i"]["rdf:Seq"]["rdf:li"]
+    seed = meta["dc:seed"]["rdf:Seq"]["rdf:li"]
+    return {"notebook": notebook, "title": title, "model": model, "i": i, "seed": seed }
+
+def get_metadata_from_steno(d):
+    data = lsb.reveal(io.BytesIO(d))
+    as_dict = json.loads(data)
+    if "notebook" not in as_dict:
+        as_dict.update(notebook="VQGAN+CLIP")
+    if "creator" in as_dict:
+        del as_dict["creator"]
+    return as_dict
+
 @bot.event
 async def on_message(message):
     if message.content.lower() == "info" and message.reference:
@@ -177,30 +204,26 @@ async def on_message(message):
             async with aiohttp.ClientSession() as session:
                 async with session.get(msg.attachments[0].url) as resp:
                     d = await resp.read()
-            xmp_start = d.find(b'<x:xmpmeta')
-            xmp_end = d.find(b'</x:xmpmeta')
-            xmp_str = d[xmp_start:xmp_end+12]
-            if not xmp_str:
+            metadata = get_metadata_from_xmp(d)
+            if not metadata:
+                metadata = get_metadata_from_steno(d)
+            if not metadata:
                 send_info_not_found(message.author.id)
-                #await message.channel.send("Esta imagen no contiene metadatos en XMP.", reference=msg, mention_author=False)
                 return
-            o = xmltodict.parse(xmp_str)
-            meta_string = json.dumps(o)
-            meta = json.loads(meta_string)
-            meta = meta["x:xmpmeta"]["rdf:RDF"]["rdf:Description"]
-            notebook = meta["dc:creator"]["rdf:Seq"]["rdf:li"]
-            title = meta["dc:title"]["rdf:Seq"]["rdf:li"]
-            model = meta["dc:model"]["rdf:Seq"]["rdf:li"]
-            i = meta["dc:i"]["rdf:Seq"]["rdf:li"]
-            seed = meta["dc:seed"]["rdf:Seq"]["rdf:li"]
-            send_info(message.author.id, notebook, title, model, i, seed, msg.author.id)
+            metadata.update(id=message.author.id, author_id=msg.author.id)
+            send_info(**metadata)
+            # send_info_json(metadata)
             #await message.channel.send(f"**Notebook:** {notebook}\n**Título(s):** {title}\n**Modelo:** {model}\n**Iteraciones:** {i}\n**Seed:** {seed}", reference=msg, mention_author=False)
     await bot.process_commands(message)
-            
+
    
-def send_info(id, notebook, title, model, iterations, seed, author_id):
-    info = Info(notebook, title, model, iterations, seed, author_id)
+def send_info(id, notebook, title, model, i, seed, author_id):
+    info = Info(notebook, title, model, i, seed, author_id)
     webhook_message = WebhookMessage(info_config, [info], content=f"<@{id}>")
+    webhook_message.send()
+
+def send_info_json(m):
+    webhook_message = WebhookMessage(info_config, [], f"{m}")
     webhook_message.send()
 
 def send_info_not_found(id):


### PR DESCRIPTION
Si no se encuentran las cadenas XMP, se intenta buscar un JSON
que viene "oculto" mediante esteganografía. Lo bueno de este enfoque
es que esos datos se conservan si la imagen se ha copiado del
notebook y pegado en el canal, no siendo necesario descargarla
y subirla.

El notebook que quiera hacer uso de esto debe incluir una cadena
JSON con los campos "title", "notebook" (o alernativamente "creator"),
"i", "model", y "seed"). Es sencillo implementarlo con la biblioteca
python stegano, por ejemplo:

```
def add_stegano_data(self, filename):
    data = {
        "title": " | ".join(args.prompts) if args.prompts else None,
        "notebook": "VQGAN+CLIP",
        "i": i,
        "model": nombre_modelo,
        "seed": str(seed)
    }
    lsb.hide(filename, json.dumps(data)).save(filename)
```